### PR TITLE
feat!: shared persistent deps dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,20 @@
   - [Logging](#logging)
   - [Error handling](#error-handling)
 - [API](#api)
-  - [isolatedFunction(code, \[options\])](#isolatedfunctioncode-options)
-    - [code](#code)
+  - [isolatedFunction(\[options\])](#isolatedfunctionoptions)
     - [options](#options)
+      - [tmpdir](#tmpdir)
+  - [=\> instance(code, \[options\])](#-instancecode-options)
+    - [code](#code)
+    - [options](#options-1)
       - [memory](#memory)
       - [throwError](#throwerror)
       - [timeout](#timeout)
-      - [tmpdir](#tmpdir)
       - [allow](#allow)
         - [permissions](#permissions)
         - [dependencies](#dependencies)
-  - [=\> (fn(\[...args\]), teardown())](#-fnargs-teardown)
-    - [fn](#fn)
-    - [teardown](#teardown)
+  - [=\> fn(\[...args\])](#-fnargs)
+  - [instance.teardown()](#instanceteardown)
 - [Environment Variables](#environment-variables)
     - [`ISOLATED_FUNCTIONS_MINIFY`](#isolated_functions_minify)
     - [`DEBUG`](#debug)
@@ -58,10 +59,10 @@ npm install isolated-function --save
 **isolated-function** is a modern solution for running untrusted code in Node.js.
 
 ```js
-const isolatedFunction = require('isolated-function')
+const isolatedFunction = require('isolated-function')()
 
 /* create an isolated-function, with resources limitation */
-const [sum, teardown] = isolatedFunction((y, z) => y + z, {
+const sum = isolatedFunction((y, z) => y + z, {
   memory: 128, // in MB
   timeout: 10000 // in milliseconds
 })
@@ -69,8 +70,8 @@ const [sum, teardown] = isolatedFunction((y, z) => y + z, {
 /* interact with the isolated-function */
 const { value, profiling } = await sum(3, 2)
 
-/* close resources associated with the isolated-function initialization */
-await teardown()
+/* close all resources on shutdown */
+await isolatedFunction.teardown()
 ```
 
 ## Minimal privilege execution
@@ -78,7 +79,7 @@ await teardown()
 The hosted code runs in a separate process, with minimal privilege, using [Node.js permission model API](https://nodejs.org/api/permissions.html#permission-model).
 
 ```js
-const [fn, teardown] = isolatedFunction(() => {
+const fn = isolatedFunction(() => {
   const fs = require('fs')
   fs.writeFileSync('/etc/passwd', 'foo')
 })
@@ -101,7 +102,7 @@ If you exceed your limit, an error will occur. Any of the following interaction 
 You can grant specific permissions to the isolated function using the `allow.permissions` option:
 
 ```js
-const [fn, teardown] = isolatedFunction(
+const fn = isolatedFunction(
   () => {
     const { execSync } = require('child_process')
     return execSync('echo hello').toString().trim()
@@ -113,7 +114,6 @@ const [fn, teardown] = isolatedFunction(
 
 const { value } = await fn()
 console.log(value) // 'hello'
-await teardown()
 ```
 
 See [#allow.permissions](#permissions) to know more.
@@ -123,7 +123,7 @@ See [#allow.permissions](#permissions) to know more.
 The hosted code is parsed for detecting `require`/`import` calls and install these dependencies:
 
 ```js
-const [isEmoji, teardown] = isolatedFunction(input => {
+const isEmoji = isolatedFunction(input => {
   /* this dependency only exists inside the isolated function */
   const isEmoji = require('is-standard-emoji@1.0.0') // default is latest
   return isEmoji(input)
@@ -131,17 +131,18 @@ const [isEmoji, teardown] = isolatedFunction(input => {
 
 await isEmoji('🙌') // => true
 await isEmoji('foo') // => false
-await teardown()
 ```
 
 The dependencies, along with the hosted code, are bundled by [esbuild](https://esbuild.github.io/) into a single file that will be evaluated at runtime.
+
+Dependencies are installed into a shared persistent directory and reused across invocations, so only the first call that requires a given package pays the install cost.
 
 ## Restricting allowed dependencies
 
 When running untrusted code, you should restrict which npm packages can be installed to prevent supply chain attacks:
 
 ```js
-const [fn, teardown] = isolatedFunction(
+const fn = isolatedFunction(
   input => {
     const isEmoji = require('is-standard-emoji')
     return isEmoji(input)
@@ -152,13 +153,12 @@ const [fn, teardown] = isolatedFunction(
 )
 
 await fn('🙌') // => true
-await teardown()
 ```
 
 If the code tries to require a package not in the allowed list, a `DependencyUnallowedError` is thrown **before** any npm install happens:
 
 ```js
-const [fn, teardown] = isolatedFunction(
+const fn = isolatedFunction(
   () => {
     const malicious = require('malicious-package')
     return malicious()
@@ -180,7 +180,7 @@ Any hosted code execution will be run in their own separate process:
 
 ```js
 /** make a function to consume ~128MB */
-const [fn, teardown] = isolatedFunction(() => {
+const fn = isolatedFunction(() => {
   const storage = []
   const oneMegabyte = 1024 * 1024
   while (storage.length < 78) {
@@ -191,7 +191,6 @@ const [fn, teardown] = isolatedFunction(() => {
     storage.push(array)
   }
 })
-t.teardown(cleanup)
 
 const { value, profiling } = await fn()
 console.log(profiling)
@@ -208,7 +207,7 @@ Each execution has a profiling, which helps understand what happened.
 You can limit a **isolated-function** by memory:
 
 ```js
-const [fn, teardown] = isolatedFunction(() => {
+const fn = isolatedFunction(() => {
   const storage = []
   const oneMegabyte = 1024 * 1024
   while (storage.length < 78) {
@@ -227,7 +226,7 @@ await fn()
 or by execution duration:
 
 ```js
-const [fn, teardown] = isolatedFunction(() => {
+const fn = isolatedFunction(() => {
   const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
   await delay(duration)
   return 'done'
@@ -242,7 +241,7 @@ await fn(100)
 The logs are collected into a `logging` object returned after the execution:
 
 ```js
-const [fn, teardown] = isolatedFunction(() => {
+const fn = isolatedFunction(() => {
   console.log('console.log')
   console.info('console.info')
   console.debug('console.debug')
@@ -251,7 +250,7 @@ const [fn, teardown] = isolatedFunction(() => {
   return 'done'
 })
 
-const { logging } await fn()
+const { logging } = await fn()
 
 console.log(logging)
 // {
@@ -268,7 +267,7 @@ console.log(logging)
 Any error during **isolated-function** execution will be propagated:
 
 ```js
-const [fn, cleanup] = isolatedFunction(() => {
+const fn = isolatedFunction(() => {
   throw new TypeError('oh no!')
 })
 
@@ -279,13 +278,16 @@ const result = await fn()
 You can also return the error instead of throwing it with `{ throwError: false }`:
 
 ```js
-const [fn, cleanup] = isolatedFunction(() => {
-  throw new TypeError('oh no!')
-})
+const fn = isolatedFunction(
+  () => {
+    throw new TypeError('oh no!')
+  },
+  { throwError: false }
+)
 
-const { isFullfiled, value } = await fn()
+const { isFulfilled, value } = await fn()
 
-if (!isFufilled) {
+if (!isFulfilled) {
   console.error(value)
   // TypeError: oh no!
 }
@@ -293,7 +295,26 @@ if (!isFufilled) {
 
 # API
 
-## isolatedFunction(code, [options])
+## isolatedFunction([options])
+
+Creates an isolated-function instance. All functions created from the same instance share the same dependencies directory.
+
+### options
+
+#### tmpdir
+
+Type: `string`<br>
+Default: `path.join(os.tmpdir(), 'isolated-fn-deps')`
+
+The directory used for installing code dependencies. Dependencies are installed once and reused across invocations, so only the first call that requires a given package pays the install cost.
+
+```js
+const isolatedFunction = require('isolated-function')({
+  tmpdir: '/tmp/my-isolated-deps'
+})
+```
+
+## => instance(code, [options])
 
 ### code
 
@@ -314,13 +335,9 @@ Set the function memory limit, in megabytes.
 #### throwError
 
 Type: `boolean`<br>
-Default: `false`
+Default: `true`
 
-When is `true`, it returns the error rather than throw it.
-
-The error will be accessible against `{ value: error, isFufilled: false }` object.
-
-Set the function memory limit, in megabytes.
+When `false`, returns the error instead of throwing it as `{ value: error, isFulfilled: false }`.
 
 #### timeout
 
@@ -328,23 +345,6 @@ Type: `number`<br>
 Default: `Infinity`
 
 Timeout after a specified amount of time, in milliseconds.
-
-#### tmpdir
-
-Type: `function`<br>
-
-It setup the temporal folder to be used for installing code dependencies.
-
-The default implementation is:
-
-```js
-const tmpdir = async () => {
-  const cwd = await fs.mkdtemp(path.join(require('os').tmpdir(), 'compile-'))
-  await fs.mkdir(cwd, { recursive: true })
-  const cleanup = () => fs.rm(cwd, { recursive: true, force: true })
-  return { cwd, cleanup }
-}
-```
 
 #### allow
 
@@ -354,7 +354,7 @@ Default: `{}`
 Configuration object for allowed permissions and dependencies.
 
 ```js
-const [fn, cleanup] = isolatedFunction(
+const fn = isolatedFunction(
   () => {
     const { execSync } = require('child_process')
     const lodash = require('lodash')
@@ -387,20 +387,6 @@ When empty, the function runs with minimal privileges and will throw an error if
 - `wasi`
 - `worker`
 
-Example:
-
-```js
-const [fn, cleanup] = isolatedFunction(
-  async () => {
-    const http = require('node:http')
-    // Network request code here
-  },
-  {
-    allow: { permissions: ['net'] }
-  }
-)
-```
-
 ##### dependencies
 
 Type: `string[]`<br>
@@ -411,7 +397,7 @@ A whitelist of npm package names that are allowed to be installed. When provided
 This is a critical security feature when running untrusted code, as it prevents arbitrary package installation which could lead to remote code execution via malicious packages.
 
 ```js
-const [fn, cleanup] = isolatedFunction(
+const fn = isolatedFunction(
   () => {
     const lodash = require('lodash')
     const axios = require('axios')
@@ -425,19 +411,21 @@ const [fn, cleanup] = isolatedFunction(
 
 When `allow.dependencies` is not provided, any package can be installed (default behavior for backwards compatibility).
 
-## => (fn([...args]), teardown())
-
-### fn
+## => fn([...args])
 
 Type: `function`
 
 The isolated function to execute. You can pass arguments over it.
 
-### teardown
+## instance.teardown()
 
 Type: `function`
 
-A function to be called to release resources associated with the **isolated-function**.
+Removes the shared dependencies directory. Call this once when shutting down the server to clean up resources.
+
+```js
+await isolatedFunction.teardown()
+```
 
 # Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
       alt="NPM Status" style="max-width: 100%;"></a>
 </h3>
 
+- [Highlights](#highlights)
 - [Install](#install)
 - [Quickstart](#quickstart)
   - [Minimal privilege execution](#minimal-privilege-execution)
@@ -46,7 +47,13 @@
     - [`DEBUG`](#debug)
 - [License](#license)
 
+# Highlights
 
+- Run untrusted code in a separate process with [Node.js Permission Model](https://nodejs.org/api/permissions.html#permission-model)
+- Automatic dependency detection, installation, and [esbuild](https://esbuild.github.io/) bundling
+- Shared persistent dependency cache across invocations
+- Memory and timeout limits with execution profiling
+- Granular permission and dependency whitelisting
 
 # Install
 

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -10,7 +10,7 @@ const detectDependencies = require('../src/compile/detect-dependencies')
 const template = require('../src/template')
 const build = require('../src/compile/build')
 
-const createIsolatedFunction = require('..')
+const compile = require('../src/compile')
 
 // @browserless/function template — generates the actual source that isolated-function compiles
 // see: packages/function/src/template.js
@@ -82,13 +82,7 @@ const compileBefore = async snippet => {
   return content
 }
 
-const compileAfter = (() => {
-  const isolatedFunction = createIsolatedFunction()
-  return async snippet => {
-    const fn = isolatedFunction(snippet)
-    return fn
-  }
-})()
+const compileAfter = snippet => compile(snippet, { allow: {} })
 
 const fmt = ms => {
   if (ms < 1) return `${(ms * 1000).toFixed(0)}µs`

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,0 +1,148 @@
+'use strict'
+
+const { mkdirSync, rmSync } = require('fs')
+const fs = require('fs/promises')
+const path = require('path')
+
+const transformDependencies = require('../src/compile/transform-dependencies')
+const installDependencies = require('../src/compile/install-dependencies')
+const detectDependencies = require('../src/compile/detect-dependencies')
+const template = require('../src/template')
+const build = require('../src/compile/build')
+
+const createIsolatedFunction = require('..')
+
+// @browserless/function template — generates the actual source that isolated-function compiles
+// see: packages/function/src/template.js
+const withResponse = `
+  const { _response: _r, ...rest } = opts
+  const response = _r
+    ? Object.fromEntries(Object.entries(_r).map(([k, v]) => [k, () => v]))
+    : undefined`
+
+const browserlessFnTemplate = (code, usesPage) => {
+  if (!usesPage) {
+    return `async (url, _, opts) => {
+    ${withResponse}
+    return (${code})({ response, ...rest })
+  }`
+  }
+  return `
+    async (url, browserWSEndpoint, opts) => {
+      ${withResponse}
+      const puppeteer = require('@cloudflare/puppeteer')
+      const browser = await puppeteer.connect({ browserWSEndpoint })
+      const pages = await browser.pages()
+      const { targetId } = opts
+      let page
+      if (targetId && pages.length > 1) {
+        for (const p of pages) {
+          try {
+            const session = await p.createCDPSession()
+            const { targetInfo } = await session.send('Target.getTargetInfo')
+            await session.detach()
+            if (targetInfo.targetId === targetId) { page = p; break }
+          } catch {}
+        }
+      }
+      if (!page) page = pages[pages.length - 1]
+      try {
+        return await (${code})({ page, response, ...rest })
+      } finally {
+        await browser.disconnect()
+      }
+    }`
+}
+
+// user functions as they arrive to @browserless/function
+const USER_FN_NO_PAGE = '({ response }) => ({ statusCode: response.status() })'
+const USER_FN_WITH_PAGE = '({ page }) => page.title()'
+
+// what isolated-function actually receives after @browserless/function wraps them
+const SNIPPET_NO_PAGE = browserlessFnTemplate(USER_FN_NO_PAGE, false)
+const SNIPPET_WITH_PAGE = browserlessFnTemplate(USER_FN_WITH_PAGE, true)
+
+const compileBefore = async snippet => {
+  const cwd = await fs.mkdtemp(path.join(require('os').tmpdir(), 'compile-'))
+  await fs.mkdir(cwd, { recursive: true })
+  const cleanup = () => fs.rm(cwd, { recursive: true, force: true })
+
+  let content = template(snippet)
+  const dependencies = detectDependencies(content)
+
+  if (dependencies.length) {
+    content = transformDependencies(content)
+    await installDependencies({ dependencies, cwd, allow: {} })
+  }
+
+  const result = await build({ content, cwd })
+  content = result.outputFiles[0].text
+  await cleanup()
+
+  return content
+}
+
+const compileAfter = (() => {
+  const isolatedFunction = createIsolatedFunction()
+  return async snippet => {
+    const fn = isolatedFunction(snippet)
+    return fn
+  }
+})()
+
+const fmt = ms => {
+  if (ms < 1) return `${(ms * 1000).toFixed(0)}µs`
+  if (ms < 1000) return `${ms.toFixed(0)}ms`
+  return `${(ms / 1000).toFixed(2)}s`
+}
+
+const bench = async (label, fn, iterations) => {
+  const times = []
+  for (let i = 0; i < iterations; i++) {
+    const start = performance.now()
+    await fn()
+    times.push(performance.now() - start)
+  }
+  const first = times[0]
+  const rest = times.slice(1)
+  const avg = rest.length ? rest.reduce((a, b) => a + b, 0) / rest.length : first
+  console.log(`  ${label}`)
+  console.log(`    1st call : ${fmt(first)}`)
+  if (rest.length) console.log(`    avg (2-${iterations}): ${fmt(avg)}`)
+  return { first, avg }
+}
+
+const { DEFAULT_TMPDIR } = require('../src/compile')
+
+const cleanDepsDir = () => {
+  rmSync(DEFAULT_TMPDIR, { recursive: true, force: true })
+  mkdirSync(DEFAULT_TMPDIR, { recursive: true })
+}
+
+const run = async () => {
+  const iterations = 5
+
+  cleanDepsDir()
+
+  console.log(`\n--- no page: no dependencies (${iterations} iterations) ---\n`)
+
+  await bench('before (tmpdir per call)', () => compileBefore(SNIPPET_NO_PAGE), iterations)
+  await bench('after  (shared deps dir)', () => compileAfter(SNIPPET_NO_PAGE), iterations)
+
+  cleanDepsDir()
+
+  console.log(`\n--- with page: @cloudflare/puppeteer (${iterations} iterations) ---\n`)
+
+  await bench('before (tmpdir per call)', () => compileBefore(SNIPPET_WITH_PAGE), iterations)
+
+  cleanDepsDir()
+
+  await bench('after  (shared deps dir)', () => compileAfter(SNIPPET_WITH_PAGE), iterations)
+
+  console.log()
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "tsd": "latest"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 24"
   },
   "files": [
     "src"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@commitlint/cli": "latest",
     "@commitlint/config-conventional": "latest",
-    "ava": "latest",
+    "ava": "7",
     "c8": "latest",
     "ci-publish": "latest",
     "finepack": "latest",

--- a/src/compile/index.js
+++ b/src/compile/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fs = require('fs/promises')
+const { mkdirSync } = require('fs')
 const path = require('path')
 
 const transformDependencies = require('./transform-dependencies')
@@ -10,34 +10,28 @@ const { debug, duration } = require('../debug')
 const template = require('../template')
 const build = require('./build')
 
-const tmpdirDefault = async () => {
-  const duration = debug.duration()
-  const cwd = await fs.mkdtemp(path.join(require('os').tmpdir(), 'compile-'))
-  await fs.mkdir(cwd, { recursive: true })
-  const cleanup = () => fs.rm(cwd, { recursive: true, force: true })
-  duration('tmpdir', { cwd })
-  return { cwd, cleanup }
-}
+const DEFAULT_TMPDIR = path.join(require('os').tmpdir(), 'isolated-fn-deps')
 
-module.exports = async (snippet, { tmpdir = tmpdirDefault, allow = {} } = {}) => {
+module.exports = async (snippet, { tmpdir = DEFAULT_TMPDIR, allow = {} } = {}) => {
   let content = template(snippet)
-  const { cwd, cleanup } = await tmpdir()
 
   const dependencies = detectDependencies(content)
   if (dependencies.length) {
     content = transformDependencies(content)
-    await duration('npm:install', () => installDependencies({ dependencies, cwd, allow }), {
+    mkdirSync(tmpdir, { recursive: true })
+    await duration('npm:install', () => installDependencies({ dependencies, cwd: tmpdir, allow }), {
       dependencies
     })
   }
 
+  const cwd = dependencies.length ? tmpdir : process.cwd()
   const result = await duration('esbuild', () => build({ content, cwd }))
   debug('esbuild:output', { content: result.outputFiles[0].text.length })
   content = result.outputFiles[0].text
-  const cleanupPromise = duration('tmpDir:cleanup', cleanup)
 
-  return { content, cleanupPromise }
+  return content
 }
 
+module.exports.DEFAULT_TMPDIR = DEFAULT_TMPDIR
 module.exports.detectDependencies = detectDependencies
 module.exports.transformDependencies = transformDependencies

--- a/src/compile/index.js
+++ b/src/compile/index.js
@@ -12,6 +12,18 @@ const build = require('./build')
 
 const DEFAULT_TMPDIR = path.join(require('os').tmpdir(), 'isolated-fn-deps')
 
+const installQueues = new Map()
+
+const enqueueInstall = (tmpdir, dependencies, allow) => {
+  const pending = installQueues.get(tmpdir) || Promise.resolve()
+  const next = pending.then(() => installDependencies({ dependencies, cwd: tmpdir, allow }))
+  installQueues.set(
+    tmpdir,
+    next.catch(() => {})
+  )
+  return next
+}
+
 module.exports = async (snippet, { tmpdir = DEFAULT_TMPDIR, allow = {} } = {}) => {
   let content = template(snippet)
 
@@ -19,7 +31,7 @@ module.exports = async (snippet, { tmpdir = DEFAULT_TMPDIR, allow = {} } = {}) =
   if (dependencies.length) {
     content = transformDependencies(content)
     mkdirSync(tmpdir, { recursive: true })
-    await duration('npm:install', () => installDependencies({ dependencies, cwd: tmpdir, allow }), {
+    await duration('npm:install', () => enqueueInstall(tmpdir, dependencies, allow), {
       dependencies
     })
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,48 +39,42 @@ export interface FailureResult {
   logging: Logging
 }
 
-/**
- * Execution result (success or failure)
- */
 export type ExecutionResult<T = unknown> = SuccessResult<T> | FailureResult
 
-/**
- * Allow configuration for permissions and dependencies
- */
 export interface AllowOptions {
   /**
-   * Array of Node.js permissions to grant to the isolated function.
-   * Available permissions: addons, child-process, fs-read, fs-write, inspector, net, wasi, worker
+   * Permissions to grant to the isolated function.
+   * Available: addons, child-process, fs-read, fs-write, inspector, net, wasi, worker
    */
   permissions?: string[]
   /**
-   * List of allowed npm package names that can be installed.
-   * When provided, only these packages can be required/imported.
-   * This prevents arbitrary package installation which could lead to RCE.
+   * Whitelist of npm package names allowed to be installed.
+   * Prevents arbitrary package installation from untrusted code.
    */
   dependencies?: string[]
+}
+
+/**
+ * Options for creating an isolated-function instance
+ */
+export interface CreateOptions {
+  /** Directory for installing code dependencies. Reused across invocations. */
+  tmpdir?: string
 }
 
 /**
  * Options for creating an isolated function
  */
 export interface IsolatedFunctionOptions {
-  /** Temporary directory configuration */
-  tmpdir?: () => Promise<{ cwd: string; cleanup: () => Promise<void> }>
   /** Execution timeout in milliseconds */
   timeout?: number
   /** Memory limit in megabytes */
   memory?: number
-  /** When false, errors are returned instead of thrown */
+  /** When false, returns the error instead of throwing it */
   throwError?: boolean
   /** Configuration for allowed permissions and dependencies */
   allow?: AllowOptions
 }
-
-/**
- * Cleanup function to release resources
- */
-export type Cleanup = () => Promise<void>
 
 /**
  * Isolated function that can be executed with arguments
@@ -89,42 +83,28 @@ export type IsolatedFn<T = unknown> = (
   ...args: unknown[]
 ) => Promise<SuccessResult<T> | FailureResult>
 
+export interface IsolatedFunctionInstance {
+  <T = unknown>(snippet: Function | string, options?: IsolatedFunctionOptions): IsolatedFn<T>
+  /** Removes the shared dependencies directory */
+  teardown(): Promise<void>
+}
+
 /**
- * Creates an isolated function that runs untrusted code in a separate Node.js process.
- *
- * @param snippet - The function or code string to run in isolation
- * @param options - Configuration options for the isolated function
- * @returns A tuple containing the isolated function and a cleanup function
+ * Creates an isolated-function instance for running untrusted code in separate Node.js processes.
  *
  * @example
  * ```js
- * const [sum, cleanup] = isolatedFunction((a, b) => a + b, {
+ * const isolatedFunction = require('isolated-function')()
+ *
+ * const sum = isolatedFunction((a, b) => a + b, {
  *   memory: 128,
  *   timeout: 10000
  * })
  *
  * const { value } = await sum(3, 2)
- * console.log(value) // 5
- * await cleanup()
- * ```
- *
- * @example
- * ```js
- * // With error handling
- * const [fn, cleanup] = isolatedFunction(() => {
- *   throw new Error('oh no!')
- * }, { throwError: false })
- *
- * const result = await fn()
- * if (!result.isFulfilled) {
- *   console.error(result.value)
- * }
- * await cleanup()
+ * await isolatedFunction.teardown()
  * ```
  */
-declare function isolatedFunction<T = unknown>(
-  snippet: Function | string,
-  options?: IsolatedFunctionOptions
-): [IsolatedFn<T>, Cleanup]
+declare function createIsolatedFunction(options?: CreateOptions): IsolatedFunctionInstance
 
-export default isolatedFunction
+export default createIsolatedFunction

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 const { deserializeError, serializeError } = require('serialize-error')
 const timeSpan = require('@kikobeats/time-span')()
 const { Readable } = require('node:stream')
+const { rm } = require('fs/promises')
 const $ = require('tinyspawn')
 
 const compile = require('./compile')
@@ -26,78 +27,84 @@ const flags = ({ memory, permissions }) => {
   return flags.join(' ')
 }
 
-module.exports = (snippet, { tmpdir, timeout, memory, throwError = true, allow = {} } = {}) => {
-  if (!['function', 'string'].includes(typeof snippet)) throw new TypeError('Expected a function')
-  const { permissions = [] } = allow
-  const compilePromise = compile(snippet, { tmpdir, allow })
+module.exports = ({ tmpdir } = {}) => {
+  const isolatedFunction = (snippet, { timeout, memory, throwError = true, allow = {} } = {}) => {
+    if (!['function', 'string'].includes(typeof snippet)) throw new TypeError('Expected a function')
+    const { permissions = [] } = allow
+    const compilePromise = compile(snippet, { tmpdir, allow })
 
-  const fn = async (...args) => {
-    let duration
-    try {
-      const { content, cleanupPromise } = await compilePromise
+    return async (...args) => {
+      let duration
+      try {
+        const content = await compilePromise
 
-      duration = timeSpan()
-      const subprocess = $('node', ['-', JSON.stringify(args)], {
-        env: {
-          ...process.env,
-          NODE_OPTIONS: flags({ memory, permissions })
-        },
-        timeout,
-        killSignal: 'SIGKILL'
-      })
-      Readable.from(content).pipe(subprocess.stdin)
-      const [{ stdout }] = await Promise.all([subprocess, cleanupPromise])
-      const { isFulfilled, value, profiling, logging } = JSON.parse(stdout)
-      profiling.duration = duration()
-      debug('node', {
-        memory: `${Math.round(profiling.memory / (1024 * 1024))}MiB`,
-        duration: `${Math.round(profiling.duration / 100)}s`
-      })
-
-      return isFulfilled
-        ? { isFulfilled, value, profiling, logging }
-        : throwError
-          ? (() => {
-              throw deserializeError(value)
-            })()
-          : { isFulfilled: false, value: deserializeError(value), profiling, logging }
-    } catch (error) {
-      debug.error(serializeError(error))
-      if (error.signalCode === 'SIGTRAP') {
-        throw createError({
-          name: 'MemoryError',
-          message: 'Out of memory',
-          profiling: { duration: duration() }
+        duration = timeSpan()
+        const subprocess = $('node', ['-', JSON.stringify(args)], {
+          env: {
+            ...process.env,
+            NODE_OPTIONS: flags({ memory, permissions })
+          },
+          timeout,
+          killSignal: 'SIGKILL'
         })
-      }
-
-      if (error.signalCode === 'SIGKILL') {
-        throw createError({
-          name: 'TimeoutError',
-          message: 'Execution timed out',
-          profiling: { duration: duration() }
+        Readable.from(content).pipe(subprocess.stdin)
+        const { stdout } = await subprocess
+        const { isFulfilled, value, profiling, logging } = JSON.parse(stdout)
+        profiling.duration = duration()
+        debug('node', {
+          memory: `${Math.round(profiling.memory / (1024 * 1024))}MiB`,
+          duration: `${Math.round(profiling.duration / 100)}s`
         })
+
+        return isFulfilled
+          ? { isFulfilled, value, profiling, logging }
+          : throwError
+            ? (() => {
+                throw deserializeError(value)
+              })()
+            : { isFulfilled: false, value: deserializeError(value), profiling, logging }
+      } catch (error) {
+        debug.error(serializeError(error))
+        if (error.signalCode === 'SIGTRAP') {
+          throw createError({
+            name: 'MemoryError',
+            message: 'Out of memory',
+            profiling: { duration: duration() }
+          })
+        }
+
+        if (error.signalCode === 'SIGKILL') {
+          throw createError({
+            name: 'TimeoutError',
+            message: 'Execution timed out',
+            profiling: { duration: duration() }
+          })
+        }
+
+        if (error.code === 'ERR_ACCESS_DENIED') {
+          const permission = error.permission
+            ? error.permission
+            : error.message.includes('getaddrinfo')
+              ? 'network'
+              : undefined
+
+          throw createError({
+            name: 'PermissionError',
+            message: `Access to '${permission}' has been restricted`,
+            profiling: { duration: duration() }
+          })
+        }
+
+        throw error
       }
-
-      if (error.code === 'ERR_ACCESS_DENIED') {
-        const permission = error.permission
-          ? error.permission
-          : error.message.includes('getaddrinfo')
-            ? 'network'
-            : undefined
-
-        throw createError({
-          name: 'PermissionError',
-          message: `Access to '${permission}' has been restricted`,
-          profiling: { duration: duration() }
-        })
-      }
-
-      throw error
     }
   }
 
-  const cleanup = async () => (await compilePromise).cleanup
+  isolatedFunction.teardown = async () => {
+    const { DEFAULT_TMPDIR } = compile
+    const dir = tmpdir || DEFAULT_TMPDIR
+    await rm(dir, { recursive: true, force: true })
+  }
 
-  return [fn, cleanup]
+  return isolatedFunction
 }

--- a/test/allow.js
+++ b/test/allow.js
@@ -2,12 +2,12 @@
 
 const test = require('ava')
 
-const isolatedFunction = require('..')
+const isolatedFunction = require('..')()
 
 const [nodeMajor] = process.version.slice(1).split('.').map(Number)
 
 test('child-process', async t => {
-  const [fn, cleanup] = isolatedFunction(
+  const fn = isolatedFunction(
     () => {
       const { execSync } = require('child_process')
       return execSync('echo hello').toString().trim()
@@ -17,13 +17,11 @@ test('child-process', async t => {
     }
   )
 
-  t.teardown(cleanup)
-
   const { value } = await fn()
   t.is(value, 'hello')
 })
 ;(nodeMajor >= 25 ? test : test.skip)('network', async t => {
-  const [fn, cleanup] = isolatedFunction(
+  const fn = isolatedFunction(
     async () => {
       function doFetch (url) {
         return new Promise((resolve, reject) => {
@@ -54,8 +52,6 @@ test('child-process', async t => {
       allow: { permissions: ['net'] }
     }
   )
-
-  t.teardown(cleanup)
 
   const { value } = await fn()
   t.is(value, 200)

--- a/test/compile/install-dependencies.js
+++ b/test/compile/install-dependencies.js
@@ -3,12 +3,12 @@
 const test = require('ava')
 
 const { DependencyNameError, DependencyUnallowedError } = require('../../src/errors')
-const isolatedFunction = require('../..')
+const isolatedFunction = require('../..')()
 
 const run = promise => Promise.resolve(promise).then(({ value }) => value)
 
 test('allow.dependencies › allows trusted dependencies', async t => {
-  const [fn, cleanup] = isolatedFunction(
+  const fn = isolatedFunction(
     emoji => {
       const isEmoji = require('is-standard-emoji@1.0.0')
       return isEmoji(emoji)
@@ -16,14 +16,12 @@ test('allow.dependencies › allows trusted dependencies', async t => {
     { allow: { dependencies: ['is-standard-emoji'] } }
   )
 
-  t.teardown(cleanup)
-
   t.is(await run(fn('🙌')), true)
   t.is(await run(fn('foo')), false)
 })
 
 test('allow.dependencies › blocks untrusted dependencies', async t => {
-  const [fn] = isolatedFunction(
+  const fn = isolatedFunction(
     emoji => {
       const isEmoji = require('is-standard-emoji@1.0.0')
       return isEmoji(emoji)
@@ -39,7 +37,7 @@ test('allow.dependencies › blocks untrusted dependencies', async t => {
 })
 
 test('allow.dependencies › allows scoped packages', async t => {
-  const [fn, cleanup] = isolatedFunction(
+  const fn = isolatedFunction(
     () => {
       const timeSpan = require('@kikobeats/time-span')
       return typeof timeSpan
@@ -47,13 +45,11 @@ test('allow.dependencies › allows scoped packages', async t => {
     { allow: { dependencies: ['@kikobeats/time-span'] } }
   )
 
-  t.teardown(cleanup)
-
   t.is(await run(fn()), 'function')
 })
 
 test('allow.dependencies › blocks untrusted scoped packages', async t => {
-  const [fn] = isolatedFunction(
+  const fn = isolatedFunction(
     () => {
       const timeSpan = require('@kikobeats/time-span')
       return typeof timeSpan
@@ -69,19 +65,17 @@ test('allow.dependencies › blocks untrusted scoped packages', async t => {
 })
 
 test('allow.dependencies › works without restriction when not provided', async t => {
-  const [fn, cleanup] = isolatedFunction(emoji => {
+  const fn = isolatedFunction(emoji => {
     const isEmoji = require('is-standard-emoji@1.0.0')
     return isEmoji(emoji)
   })
-
-  t.teardown(cleanup)
 
   t.is(await run(fn('🙌')), true)
 })
 
 test('allow.dependencies › handles multiple dependencies', async t => {
   {
-    const [fn, cleanup] = isolatedFunction(
+    const fn = isolatedFunction(
       () => {
         const isEmoji = require('is-standard-emoji@1.0.0')
         const isNumber = require('is-number')
@@ -90,11 +84,10 @@ test('allow.dependencies › handles multiple dependencies', async t => {
       { allow: { dependencies: ['is-standard-emoji', 'is-number'] } }
     )
 
-    t.teardown(cleanup)
     t.is(await run(fn()), true)
   }
   {
-    const [fn] = isolatedFunction(
+    const fn = isolatedFunction(
       () => {
         const isEmoji = require('is-standard-emoji@1.0.0')
         const isNumber = require('is-number')
@@ -110,7 +103,7 @@ test('allow.dependencies › handles multiple dependencies', async t => {
 })
 
 test('allow.dependencies › blocks invalid package names with spaces', async t => {
-  const [fn] = isolatedFunction(
+  const fn = isolatedFunction(
     () => {
       const _ = require('lodash@latest express')
       return typeof _
@@ -126,7 +119,7 @@ test('allow.dependencies › blocks invalid package names with spaces', async t 
 })
 
 test('allow.dependencies › blocks invalid package names even without allow list', async t => {
-  const [fn] = isolatedFunction(() => {
+  const fn = isolatedFunction(() => {
     const _ = require('lodash@latest express')
     return typeof _
   })

--- a/test/error.js
+++ b/test/error.js
@@ -2,7 +2,7 @@
 
 const test = require('ava')
 
-const isolatedFunction = require('..')
+const isolatedFunction = require('..')()
 
 const [nodeMajor] = process.version.slice(1).split('.').map(Number)
 
@@ -16,24 +16,22 @@ test('throw an error if snippet is not a function or string', t => {
 })
 
 test('throw code errors by default', async t => {
-  const [fn, cleanup] = isolatedFunction(() => {
+  const fn = isolatedFunction(() => {
     throw new TypeError('oops')
   })
 
-  t.teardown(cleanup)
   await t.throwsAsync(fn(), { message: 'oops' })
 })
 
 test('pass `throwError: false`', async t => {
   {
-    const [fn, cleanup] = isolatedFunction(
+    const fn = isolatedFunction(
       () => {
         throw new TypeError('oops')
       },
       { throwError: false }
     )
 
-    t.teardown(cleanup)
     const result = await fn()
 
     t.is(result.isFulfilled, false)
@@ -42,14 +40,13 @@ test('pass `throwError: false`', async t => {
     t.is(typeof result.profiling, 'object')
   }
   {
-    const [fn, cleanup] = isolatedFunction(
+    const fn = isolatedFunction(
       () => {
         throw 'oops'
       },
       { throwError: false }
     )
 
-    t.teardown(cleanup)
     const result = await fn()
 
     t.is(result.isFulfilled, false)
@@ -60,7 +57,7 @@ test('pass `throwError: false`', async t => {
 })
 
 test('handle timeout', async t => {
-  const [fn, cleanup] = isolatedFunction(
+  const fn = isolatedFunction(
     () => {
       let i = 0
       while (true) {
@@ -69,7 +66,6 @@ test('handle timeout', async t => {
     },
     { timeout: 100 }
   )
-  t.teardown(cleanup)
 
   const error = await t.throwsAsync(fn())
 
@@ -78,7 +74,7 @@ test('handle timeout', async t => {
 })
 
 test('handle OOM', async t => {
-  const [fn, cleanup] = isolatedFunction(
+  const fn = isolatedFunction(
     () => {
       const storage = []
       const twoMegabytes = 1024 * 1024 * 2
@@ -92,7 +88,6 @@ test('handle OOM', async t => {
     },
     { memory: 1 }
   )
-  t.teardown(cleanup)
 
   const error = await t.throwsAsync(fn())
 
@@ -102,24 +97,20 @@ test('handle OOM', async t => {
 
 test('handle filesystem permissions', async t => {
   {
-    const [fn, cleanup] = isolatedFunction(() => {
+    const fn = isolatedFunction(() => {
       const fs = require('fs')
       fs.readFileSync('/etc/passwd', 'utf8')
     })
-
-    t.teardown(cleanup)
 
     const error = await t.throwsAsync(fn())
 
     t.is(error.message, "Access to 'FileSystemRead' has been restricted")
   }
   {
-    const [fn, cleanup] = isolatedFunction(() => {
+    const fn = isolatedFunction(() => {
       const fs = require('fs')
       fs.writeFileSync('/etc/passwd', 'foo')
     })
-
-    t.teardown(cleanup)
 
     const error = await t.throwsAsync(fn())
 
@@ -129,12 +120,10 @@ test('handle filesystem permissions', async t => {
 
 test('handle child process', async t => {
   {
-    const [fn, cleanup] = isolatedFunction(() => {
+    const fn = isolatedFunction(() => {
       const { execSync } = require('child_process')
       return execSync('echo hello').toString()
     })
-
-    t.teardown(cleanup)
 
     const error = await t.throwsAsync(fn())
 
@@ -143,7 +132,7 @@ test('handle child process', async t => {
 })
 
 test('handle untrusted dependencies', async t => {
-  const [fn] = isolatedFunction(
+  const fn = isolatedFunction(
     () => {
       const malicious = require('malicious-package')
       return malicious()
@@ -159,7 +148,7 @@ test('handle untrusted dependencies', async t => {
 })
 ;(nodeMajor >= 25 ? test : test.skip)('handle network access', async t => {
   {
-    const [fn, cleanup] = isolatedFunction(async () => {
+    const fn = isolatedFunction(async () => {
       function doFetch (url) {
         return new Promise((resolve, reject) => {
           const req = require('node:http').get(url, res => {
@@ -185,8 +174,6 @@ test('handle untrusted dependencies', async t => {
       const { statusCode } = await doFetch('http://example.com')
       return statusCode
     })
-
-    t.teardown(cleanup)
 
     const error = await t.throwsAsync(fn())
     t.is(error.message, "Access to 'network' has been restricted")

--- a/test/index.js
+++ b/test/index.js
@@ -2,47 +2,28 @@
 
 const test = require('ava')
 
-const isolatedFunction = require('..')
+const isolatedFunction = require('..')()
 
 const run = promise => Promise.resolve(promise).then(({ value }) => value)
 
 test('runs plain javascript', async t => {
-  {
-    const [sum, cleanup] = isolatedFunction(() => 2 + 2)
-    t.teardown(cleanup)
-    t.is(await run(sum()), 4)
-  }
-  {
-    const [sum, cleanup] = isolatedFunction(String(() => 2 + 2))
-    t.teardown(cleanup)
-    t.is(await run(sum()), 4)
-  }
-  {
-    const [sum, cleanup] = isolatedFunction('() => 2 + 2')
-    t.teardown(cleanup)
-    t.is(await run(sum()), 4)
-  }
-  {
-    const [sum, cleanup] = isolatedFunction((x, y) => x + y)
-    t.teardown(cleanup)
-    t.is(await run(sum(2, 2)), 4)
-  }
-  {
-    const [fn, cleanup] = isolatedFunction(() => 2 + 2)
-    t.teardown(cleanup)
-    t.is(await run(fn()), 4)
-  }
-  {
-    const [fn, cleanup] = isolatedFunction(function () {
-      return 2 + 2
-    })
-    t.teardown(cleanup)
-    t.is(await run(fn()), 4)
-  }
+  t.is(await run(isolatedFunction(() => 2 + 2)()), 4)
+  t.is(await run(isolatedFunction(String(() => 2 + 2))()), 4)
+  t.is(await run(isolatedFunction('() => 2 + 2')()), 4)
+  t.is(await run(isolatedFunction((x, y) => x + y)(2, 2)), 4)
+  t.is(await run(isolatedFunction(() => 2 + 2)()), 4)
+  t.is(
+    await run(
+      isolatedFunction(function () {
+        return 2 + 2
+      })()
+    ),
+    4
+  )
 })
 
 test('capture logs', async t => {
-  const [fn, cleanup] = isolatedFunction(() => {
+  const fn = isolatedFunction(() => {
     console.log('console.log', { foo: 'bar' })
     console.info('console.info')
     console.debug('console.debug')
@@ -50,8 +31,6 @@ test('capture logs', async t => {
     console.error('console.error')
     return 'done'
   })
-
-  t.teardown(cleanup)
 
   const { value, logging } = await fn()
   t.is(value, 'done')
@@ -72,12 +51,10 @@ test('capture logs', async t => {
 })
 
 test('prevent to write to process.stdout', async t => {
-  const [fn, cleanup] = isolatedFunction(() => {
+  const fn = isolatedFunction(() => {
     process.stdout.write('disturbing')
     return 'done'
   })
-
-  t.teardown(cleanup)
 
   const { value, logging } = await fn()
   t.is(value, 'done')
@@ -85,31 +62,27 @@ test('prevent to write to process.stdout', async t => {
 })
 
 test('resolve require dependencies', async t => {
-  const [fn, cleanup] = isolatedFunction(emoji => {
+  const fn = isolatedFunction(emoji => {
     const isEmoji = require('is-standard-emoji@1.0.0')
     return isEmoji(emoji)
   })
-
-  t.teardown(cleanup)
 
   t.is(await run(fn('🙌')), true)
   t.is(await run(fn('foo')), false)
 })
 
 test('runs async code', async t => {
-  const [fn, cleanup] = isolatedFunction(async duration => {
+  const fn = isolatedFunction(async duration => {
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
     await delay(duration)
     return 'done'
   })
 
-  t.teardown(cleanup)
   t.is(await run(fn(200)), 'done')
 })
 
 test('escape arguments', async t => {
-  const [fn, cleanup] = isolatedFunction((...args) => args.length)
-  t.teardown(cleanup)
+  const fn = isolatedFunction((...args) => args.length)
 
   const result = await run(
     fn({
@@ -132,7 +105,7 @@ test('escape arguments', async t => {
 })
 
 test('memory profiling', async t => {
-  const [fn, cleanup] = isolatedFunction(() => {
+  const fn = isolatedFunction(() => {
     const storage = []
     const oneMegabyte = 1024 * 1024
     while (storage.length < 78) {
@@ -143,7 +116,6 @@ test('memory profiling', async t => {
       storage.push(array)
     }
   })
-  t.teardown(cleanup)
 
   const { value, profiling } = await fn()
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,28 +1,34 @@
 import { expectType, expectAssignable } from 'tsd'
-import isolatedFunction, {
+import createIsolatedFunction, {
   ExecutionResult,
   FailureResult,
   SuccessResult,
   Profiling,
   Logging,
   IsolatedFunctionOptions,
-  Cleanup,
+  IsolatedFunctionInstance,
   IsolatedFn
 } from '..'
 
+/* instance creation */
+
+const isolatedFunction = createIsolatedFunction()
+expectType<IsolatedFunctionInstance>(isolatedFunction)
+
+const customInstance = createIsolatedFunction({ tmpdir: '/tmp/custom' })
+expectType<IsolatedFunctionInstance>(customInstance)
+
 /* basic usage */
 
-const [fn, cleanup] = isolatedFunction(() => 2 + 2)
+const fn = isolatedFunction(() => 2 + 2)
 
 expectType<IsolatedFn>(fn)
-expectType<Cleanup>(cleanup)
 
 /* with explicit generic */
 
-const [sumFn, sumCleanup] = isolatedFunction<number>((a: number, b: number) => a + b)
+const sumFn = isolatedFunction<number>((a: number, b: number) => a + b)
 
 expectType<IsolatedFn<number>>(sumFn)
-expectType<Cleanup>(sumCleanup)
 
 /* function execution - success case */
 
@@ -46,7 +52,7 @@ if (result.isFulfilled) {
 
 /* with options */
 
-const [fnWithOptions, cleanupWithOptions] = isolatedFunction<string>(
+const fnWithOptions = isolatedFunction<string>(
   () => 'hello',
   {
     memory: 128,
@@ -57,11 +63,10 @@ const [fnWithOptions, cleanupWithOptions] = isolatedFunction<string>(
 )
 
 expectType<IsolatedFn<string>>(fnWithOptions)
-expectType<Cleanup>(cleanupWithOptions)
 
 /* error handling with throwError: false */
 
-const [errorFn, errorCleanup] = isolatedFunction<string>(
+const errorFn = isolatedFunction<string>(
   () => {
     throw new Error('test')
   },
@@ -106,13 +111,13 @@ if (execResult.isFulfilled) {
 
 /* string input */
 
-const [stringFn, stringCleanup] = isolatedFunction('() => 42')
+const stringFn = isolatedFunction('() => 42')
 
 expectType<IsolatedFn>(stringFn)
 
 /* async function */
 
-const [asyncFn, asyncCleanup] = isolatedFunction<string>(async () => {
+const asyncFn = isolatedFunction<string>(async () => {
   await new Promise(resolve => setTimeout(resolve, 100))
   return 'done'
 })
@@ -125,7 +130,7 @@ if (asyncResult.isFulfilled) {
 
 /* variadic arguments */
 
-const [variadicFn, variadicCleanup] = isolatedFunction<number>(
+const variadicFn = isolatedFunction<number>(
   (...args: number[]) => args.reduce((a, b) => a + b, 0)
 )
 
@@ -135,8 +140,8 @@ if (variadicResult.isFulfilled) {
   expectType<number>(variadicResult.value)
 }
 
-/* cleanup function */
+/* teardown */
 
-const cleanupResult = await cleanup()
+const teardownResult = await isolatedFunction.teardown()
 
-expectType<void>(cleanupResult)
+expectType<void>(teardownResult)


### PR DESCRIPTION
Install dependencies once into a shared tmpdir and reuse across invocations instead of creating a fresh tmpdir per call.

BREAKING CHANGE: API is now a factory — `require('isolated-function')()` returns an instance. Functions return directly instead of `[fn, teardown]` tuple. `instance.teardown()` replaces per-function cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a **breaking API change** (factory/instance + new teardown semantics) and a shift to a shared on-disk dependency cache with queued installs, which could affect concurrency and cleanup behavior.
> 
> **Overview**
> **Switches dependency installs from per-call temp dirs to a shared persistent `tmpdir` cache**, so detected npm deps are installed once and reused across invocations (with a per-`tmpdir` install queue to avoid concurrent installs racing).
> 
> **BREAKING:** the public API is now a factory (`require('isolated-function')()` returns an instance); creating a function returns `fn` directly (no `[fn, teardown]` tuple), and cleanup is now `instance.teardown()` that removes the shared deps directory.
> 
> Updates TypeScript types, tests, and README to reflect the new API, adds a benchmark script comparing old vs new compile behavior, and bumps the Node engine requirement to `>=24` (plus pins `ava` to `7`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f4088eb2d7372e0a69787fcba8470d08c5bd0b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->