### PR TITLE
feat: add ffi permission, path-scoped fs, and missing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,6 @@ await fn()
 // => PermissionError: Access to 'FileSystemWrite' has been restricted.
 ```
 
-If you exceed your limit, an error will occur. Any of the following interaction will throw an error:
-
-- Native modules
-- Child process
-- Worker Threads
-- Inspector protocol
-- File system access
-- WASI
-
 ## Granting specific permissions
 
 You can grant specific permissions to the isolated function using the `allow.permissions` option:
@@ -385,14 +376,32 @@ An array of permissions to grant to the isolated function based on [Node.js Opti
 
 When empty, the function runs with minimal privileges and will throw an error if it attempts to access restricted resources. Available permissions are:
 
-- `addons`
-- `child-process`
-- `fs-read`
-- `fs-write`
-- `inspector`
-- `net`
-- `wasi`
-- `worker`
+- `addons` — e.g. <small>*`require('native-module')`*</small><br/>
+  Allow loading native C++ addons.
+
+- `child-process` — e.g. <small>*`execSync('echo hello')`*</small><br/>
+  Allow spawning child processes via `child_process` module.
+
+- `ffi` *(Node.js v26+)* — e.g. <small>*`ffi.open('libc.so')`*</small><br/>
+  Allow foreign function interface calls to shared libraries.
+
+- `fs-read` — e.g. <small>*`fs.readFileSync('/etc/hosts')`*</small><br/>
+  Allow reading from the filesystem. Supports path scoping: `fs-read=/etc/hosts`.
+
+- `fs-write` — e.g. <small>*`fs.writeFileSync('/tmp/out.txt', data)`*</small><br/>
+  Allow writing to the filesystem. Supports path scoping: `fs-write=/tmp`.
+
+- `inspector` — e.g. <small>*`require('inspector').open()`*</small><br/>
+  Allow the inspector protocol for debugging.
+
+- `net` *(Node.js v25+)* — e.g. <small>*`http.get('http://example.com')`*</small><br/>
+  Allow outbound network connections.
+
+- `wasi` — e.g. <small>*`new WASI({ args, env })`*</small><br/>
+  Allow WebAssembly System Interface operations.
+
+- `worker` — e.g. <small>*`new Worker('./task.js')`*</small><br/>
+  Allow creating worker threads.
 
 ##### dependencies
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+overrides:
+  c8>yargs: "npm:yargs@18"

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ const PERMISSION_FLAG = nodeMajor >= 24 ? '--permission' : '--experimental-permi
 const flags = ({ memory, permissions }) => {
   const flags = ['--disable-warning=ExperimentalWarning', PERMISSION_FLAG]
   if (memory) flags.push(`--max-old-space-size=${memory}`)
+  if (permissions.includes('ffi')) flags.push('--experimental-ffi')
   permissions.forEach(resource => flags.push(`--allow-${resource}`))
   return flags.join(' ')
 }

--- a/test/allow.js
+++ b/test/allow.js
@@ -56,3 +56,41 @@ test('child-process', async t => {
   const { value } = await fn()
   t.is(value, 200)
 })
+
+test('worker', async t => {
+  const fn = isolatedFunction(
+    () => {
+      const { Worker, isMainThread } = require('worker_threads')
+      if (isMainThread) {
+        return new Promise(resolve => {
+          const worker = new Worker(
+            'const { parentPort } = require("worker_threads"); parentPort.postMessage("hello")',
+            { eval: true }
+          )
+          worker.on('message', resolve)
+        })
+      }
+    },
+    {
+      allow: { permissions: ['worker'] }
+    }
+  )
+
+  const { value } = await fn()
+  t.is(value, 'hello')
+})
+
+test('fs-read with path scope', async t => {
+  const fn = isolatedFunction(
+    () => {
+      const fs = require('fs')
+      return fs.readFileSync('/etc/hosts', 'utf8').length > 0
+    },
+    {
+      allow: { permissions: ['fs-read=/etc/hosts'] }
+    }
+  )
+
+  const { value } = await fn()
+  t.true(value)
+})

--- a/test/error.js
+++ b/test/error.js
@@ -119,16 +119,25 @@ test('handle filesystem permissions', async t => {
 })
 
 test('handle child process', async t => {
-  {
-    const fn = isolatedFunction(() => {
-      const { execSync } = require('child_process')
-      return execSync('echo hello').toString()
-    })
+  const fn = isolatedFunction(() => {
+    const { execSync } = require('child_process')
+    return execSync('echo hello').toString()
+  })
 
-    const error = await t.throwsAsync(fn())
+  const error = await t.throwsAsync(fn())
 
-    t.is(error.message, "Access to 'ChildProcess' has been restricted")
-  }
+  t.is(error.message, "Access to 'ChildProcess' has been restricted")
+})
+
+test('handle worker threads', async t => {
+  const fn = isolatedFunction(() => {
+    const { Worker } = require('worker_threads')
+    new Worker('', { eval: true })
+  })
+
+  const error = await t.throwsAsync(fn())
+
+  t.is(error.message, "Access to 'WorkerThreads' has been restricted")
 })
 
 test('handle untrusted dependencies', async t => {


### PR DESCRIPTION
Node.js v26 added --allow-ffi; auto-enable --experimental-ffi when requested. Document all permissions with inline examples and version notes. Add worker + path-scoped fs-read allow tests and worker threads error test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the sandboxing/permission model by altering how Node is launched (auto-adding `--experimental-ffi` when `ffi` is requested), so misconfiguration could broaden capabilities in isolated code. Additional tests and doc updates reduce regression risk but don’t eliminate runtime/version-specific edge cases.
> 
> **Overview**
> Adds `ffi` permission support by auto-including `--experimental-ffi` in `NODE_OPTIONS` when `allow.permissions` contains `ffi`, enabling Node v26+ FFI usage in isolated executions.
> 
> Expands and clarifies `README` permission documentation (inline examples, version notes, and path-scoped `fs-read`/`fs-write` syntax), and adds/adjusts tests to cover allowed `worker` usage, path-scoped `fs-read`, and the expected permission error for denied worker thread creation.
> 
> Pins a workspace override (`c8>yargs`) via `pnpm-workspace.yaml` to stabilize tooling dependency resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd232a8ff388a332350f31b47c3ff5dae3402bf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->