### PR TITLE
feat: add CPU time limit and phased execution profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 - Run untrusted code in a separate process with [Node.js Permission Model](https://nodejs.org/api/permissions.html#permission-model)
 - Automatic dependency detection, installation, and [esbuild](https://esbuild.github.io/) bundling
 - Shared persistent dependency cache across invocations
-- Memory and timeout limits with execution profiling
+- Memory, timeout, and CPU time limits with phased execution profiling
 - Granular permission and dependency whitelisting
 
 # Install
@@ -193,12 +193,26 @@ const fn = isolatedFunction(() => {
 const { value, profiling } = await fn()
 console.log(profiling)
 // {
+//   cpu: 42.5,
 //   memory: 128204800,
-//   duration: 54.98325
+//   phases: {
+//     compile: 0,
+//     spawn: 48,
+//     run: 54,
+//     total: 102
+//   }
 // }
 ```
 
-Each execution has a profiling, which helps understand what happened.
+Each execution includes profiling data:
+
+- **cpu** — CPU time (user + system) consumed by the process, in milliseconds.
+- **memory** — Peak RSS (Resident Set Size) of the process, in bytes.
+- **phases** — Wall-clock time breakdown of each execution stage, in milliseconds:
+  - **compile** — Time waiting for code compilation (dependency detection, npm install, esbuild bundling). This is `0` after the first call since the result is cached.
+  - **spawn** — Process creation, Node.js boot, and template setup overhead.
+  - **run** — User function execution time.
+  - **total** — End-to-end wall-clock time.
 
 ## Resource limits
 
@@ -221,7 +235,7 @@ await fn()
 // =>  MemoryError: Out of memory
 ```
 
-or by execution duration:
+or by execution time:
 
 ```js
 const fn = isolatedFunction(() => {
@@ -232,6 +246,17 @@ const fn = isolatedFunction(() => {
 
 await fn(100)
 // =>  TimeoutError: Execution timed out
+```
+
+The `timeout` option enforces both a wall-clock limit (`SIGKILL`) and a CPU time limit (`RLIMIT_CPU`). A CPU-bound infinite loop will be terminated by the kernel via `SIGXCPU`:
+
+```js
+const fn = isolatedFunction(() => {
+  while (true) { Math.random() }
+}, { timeout: 5000 })
+
+await fn()
+// => CpuTimeError: CPU time limit exceeded
 ```
 
 ## Logging
@@ -342,7 +367,7 @@ When `false`, returns the error instead of throwing it as `{ value: error, isFul
 Type: `number`<br>
 Default: `Infinity`
 
-Timeout after a specified amount of time, in milliseconds.
+Timeout after a specified amount of time, in milliseconds. Enforces both a wall-clock limit (via `SIGKILL`) and a CPU time limit (via `RLIMIT_CPU`/`SIGXCPU`).
 
 #### allow
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,11 +1,24 @@
 /**
  * Profiling information about the isolated function execution
  */
+export interface Phases {
+  /** Time waiting for compilation in milliseconds (0 if cached) */
+  compile: number
+  /** Process creation + Node.js boot + template setup in milliseconds */
+  spawn: number
+  /** User function execution time in milliseconds */
+  run: number
+  /** End-to-end wall-clock time in milliseconds */
+  total: number
+}
+
 export interface Profiling {
+  /** CPU time (user + system) in milliseconds */
+  cpu: number
   /** Memory usage in bytes */
   memory: number
-  /** Execution duration in milliseconds */
-  duration: number
+  /** Execution phase durations in milliseconds */
+  phases: Phases
 }
 
 /**
@@ -66,7 +79,7 @@ export interface CreateOptions {
  * Options for creating an isolated function
  */
 export interface IsolatedFunctionOptions {
-  /** Execution timeout in milliseconds */
+  /** Execution timeout in milliseconds. Also enforces a CPU time limit via RLIMIT_CPU. */
   timeout?: number
   /** Memory limit in megabytes */
   memory?: number

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,15 @@ const flags = ({ memory, permissions }) => {
   return flags.join(' ')
 }
 
+const spawn = ({ args, env, timeout }) => {
+  const spawnOpts = { env, timeout, killSignal: 'SIGKILL' }
+  if (timeout) {
+    const seconds = Math.ceil(timeout / 1000)
+    return $('sh', ['-c', `ulimit -t ${seconds} && exec node "$@"`, '_', '-', args], spawnOpts)
+  }
+  return $('node', ['-', args], spawnOpts)
+}
+
 module.exports = ({ tmpdir } = {}) => {
   const isolatedFunction = (snippet, { timeout, memory, throwError = true, allow = {} } = {}) => {
     if (!['function', 'string'].includes(typeof snippet)) throw new TypeError('Expected a function')
@@ -35,42 +44,59 @@ module.exports = ({ tmpdir } = {}) => {
     const compilePromise = compile(snippet, { tmpdir, allow })
 
     return async (...args) => {
-      let duration
+      let total
       try {
+        total = timeSpan()
         const content = await compilePromise
+        const compileMs = total()
 
-        duration = timeSpan()
-        const subprocess = $('node', ['-', JSON.stringify(args)], {
+        const subprocess = spawn({
+          args: JSON.stringify(args),
           env: {
             ...process.env,
             NODE_OPTIONS: flags({ memory, permissions })
           },
-          timeout,
-          killSignal: 'SIGKILL'
+          timeout
         })
+        subprocess.stdin.on('error', () => {})
         Readable.from(content).pipe(subprocess.stdin)
         const { stdout } = await subprocess
         const { isFulfilled, value, profiling, logging } = JSON.parse(stdout)
-        profiling.duration = duration()
+        const totalMs = total()
+        const { run, ...rest } = profiling
+        const result = {
+          ...rest,
+          phases: {
+            compile: compileMs,
+            spawn: totalMs - compileMs - run,
+            run,
+            total: totalMs
+          }
+        }
         debug('node', {
-          memory: `${Math.round(profiling.memory / (1024 * 1024))}MiB`,
-          duration: `${Math.round(profiling.duration / 100)}s`
+          cpu: `${Math.round(result.cpu)}ms`,
+          memory: `${Math.round(result.memory / (1024 * 1024))}MiB`,
+          phases: `compile=${Math.round(result.phases.compile)}ms spawn=${Math.round(
+            result.phases.spawn
+          )}ms run=${Math.round(result.phases.run)}ms total=${Math.round(result.phases.total)}ms`
         })
 
         return isFulfilled
-          ? { isFulfilled, value, profiling, logging }
+          ? { isFulfilled, value, profiling: result, logging }
           : throwError
             ? (() => {
                 throw deserializeError(value)
               })()
-            : { isFulfilled: false, value: deserializeError(value), profiling, logging }
+            : { isFulfilled: false, value: deserializeError(value), profiling: result, logging }
       } catch (error) {
         debug.error(serializeError(error))
+        const profiling = { phases: { total: total() } }
+
         if (error.signalCode === 'SIGTRAP') {
           throw createError({
             name: 'MemoryError',
             message: 'Out of memory',
-            profiling: { duration: duration() }
+            profiling
           })
         }
 
@@ -78,7 +104,15 @@ module.exports = ({ tmpdir } = {}) => {
           throw createError({
             name: 'TimeoutError',
             message: 'Execution timed out',
-            profiling: { duration: duration() }
+            profiling
+          })
+        }
+
+        if (error.signalCode === 'SIGXCPU') {
+          throw createError({
+            name: 'CpuTimeError',
+            message: 'CPU time limit exceeded',
+            profiling
           })
         }
 
@@ -92,7 +126,7 @@ module.exports = ({ tmpdir } = {}) => {
           throw createError({
             name: 'PermissionError',
             message: `Access to '${permission}' has been restricted`,
-            profiling: { duration: duration() }
+            profiling
           })
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ const flags = ({ memory, permissions }) => {
 
 const spawn = ({ args, env, timeout }) => {
   const spawnOpts = { env, timeout, killSignal: 'SIGKILL' }
-  if (timeout) {
+  if (Number.isFinite(timeout)) {
     const seconds = Math.ceil(timeout / 1000)
     return $('sh', ['-c', `ulimit -t ${seconds} && exec node "$@"`, '_', '-', args], spawnOpts)
   }

--- a/src/template/index.js
+++ b/src/template/index.js
@@ -4,7 +4,7 @@ const SERIALIZE_ERROR = require('./serialize-error')
 
 module.exports = snippet => `;(send => {
   process.stdout.write = function () {}
-  const respond = (isFulfilled, value, logs = {}) => send(JSON.stringify({isFulfilled, logging: logs, value, profiling: {memory: process.memoryUsage().rss}}))
+  const respond = (isFulfilled, value, run, logs = {}) => { const {user, system} = process.cpuUsage(); send(JSON.stringify({isFulfilled, logging: logs, value, profiling: {cpu: (user + system) / 1000, memory: process.memoryUsage().rss, run}})) }
 
   return Promise.resolve().then(async () => {
     const args = JSON.parse(process.argv[2])
@@ -19,6 +19,7 @@ module.exports = snippet => `;(send => {
 
     let value
     let isFulfilled
+    const t0 = performance.now()
     try {
       value = await (${snippet.toString()})(...args)
       isFulfilled = true
@@ -26,7 +27,7 @@ module.exports = snippet => `;(send => {
       value = ${SERIALIZE_ERROR}(error)
       isFulfilled = false
     } finally {
-      respond(isFulfilled, value, logging)
+      respond(isFulfilled, value, performance.now() - t0, logging)
     }
   })
   .catch(e => respond(false, ${SERIALIZE_ERROR}(e)))

--- a/src/template/index.js
+++ b/src/template/index.js
@@ -30,5 +30,5 @@ module.exports = snippet => `;(send => {
       respond(isFulfilled, value, performance.now() - t0, logging)
     }
   })
-  .catch(e => respond(false, ${SERIALIZE_ERROR}(e)))
+  .catch(e => respond(false, ${SERIALIZE_ERROR}(e), 0))
 })(process.stdout.write.bind(process.stdout))`

--- a/test/error.js
+++ b/test/error.js
@@ -70,7 +70,23 @@ test('handle timeout', async t => {
   const error = await t.throwsAsync(fn())
 
   t.is(error.message, 'Execution timed out')
-  t.is(typeof error.profiling.duration, 'number')
+  t.is(typeof error.profiling.phases.total, 'number')
+})
+
+test('handle CPU time limit', async t => {
+  const fn = isolatedFunction(
+    () => {
+      while (true) {
+        Math.random()
+      }
+    },
+    { timeout: 5000 }
+  )
+
+  const error = await t.throwsAsync(fn())
+
+  t.true(['Execution timed out', 'CPU time limit exceeded'].includes(error.message))
+  t.is(typeof error.profiling.phases.total, 'number')
 })
 
 test('handle OOM', async t => {
@@ -92,7 +108,7 @@ test('handle OOM', async t => {
   const error = await t.throwsAsync(fn())
 
   t.is(error.message, 'Out of memory')
-  t.is(typeof error.profiling.duration, 'number')
+  t.is(typeof error.profiling.phases.total, 'number')
 })
 
 test('handle filesystem permissions', async t => {

--- a/test/index.js
+++ b/test/index.js
@@ -120,6 +120,10 @@ test('memory profiling', async t => {
   const { value, profiling } = await fn()
 
   t.is(value, undefined)
+  t.is(typeof profiling.cpu, 'number')
   t.is(typeof profiling.memory, 'number')
-  t.is(typeof profiling.duration, 'number')
+  t.is(typeof profiling.phases.compile, 'number')
+  t.is(typeof profiling.phases.spawn, 'number')
+  t.is(typeof profiling.phases.run, 'number')
+  t.is(typeof profiling.phases.total, 'number')
 })

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -98,8 +98,12 @@ const execResult = await fn()
 if (execResult.isFulfilled) {
   const { profiling, logging } = execResult
 
+  expectType<number>(profiling.cpu)
   expectType<number>(profiling.memory)
-  expectType<number>(profiling.duration)
+  expectType<number>(profiling.phases.compile)
+  expectType<number>(profiling.phases.spawn)
+  expectType<number>(profiling.phases.run)
+  expectType<number>(profiling.phases.total)
 
   expectType<Logging>(logging)
   expectAssignable<unknown[][] | undefined>(logging.log)


### PR DESCRIPTION
timeout now enforces RLIMIT_CPU via ulimit, killing CPU-bound loops with SIGXCPU. Profiling replaced with phased breakdown: compile, spawn, run, total — plus cpu (user+system) and memory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how subprocesses are spawned to enforce `RLIMIT_CPU` via `ulimit`, and reshapes the public `profiling` payload (replacing `duration` with `cpu` + `phases`), which may break consumers and impacts execution/termination behavior.
> 
> **Overview**
> Adds CPU-time enforcement to `timeout` by spawning the child process through `sh` with `ulimit -t`, surfacing `SIGXCPU` as a new `CpuTimeError` (in addition to wall-clock `SIGKILL`).
> 
> Reworks profiling output: replaces `duration` with `cpu` plus a **phased** wall-clock breakdown (`compile`, `spawn`, `run`, `total`), updates the runtime template to emit CPU/run timing, and refreshes docs, TypeScript types, and tests to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9be10ddbc293887ab91a876fa8d2bb5ebf5f6c72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->