### PR TITLE
chore: compact logging

### DIFF
--- a/src/compile/index.js
+++ b/src/compile/index.js
@@ -7,7 +7,6 @@ const transformDependencies = require('./transform-dependencies')
 const installDependencies = require('./install-dependencies')
 const detectDependencies = require('./detect-dependencies')
 const timeSpan = require('@kikobeats/time-span')()
-const { debug, duration } = require('../debug')
 const template = require('../template')
 const build = require('./build')
 
@@ -34,17 +33,14 @@ module.exports = async (snippet, { tmpdir = DEFAULT_TMPDIR, allow = {} } = {}) =
     content = transformDependencies(content)
     mkdirSync(tmpdir, { recursive: true })
     const elapsed = timeSpan()
-    await duration('npm:install', () => enqueueInstall(tmpdir, dependencies, allow), {
-      dependencies
-    })
+    await enqueueInstall(tmpdir, dependencies, allow)
     phases.install = elapsed()
   }
 
   const cwd = dependencies.length ? tmpdir : process.cwd()
   const elapsed = timeSpan()
-  const result = await duration('esbuild', () => build({ content, cwd }))
+  const result = await build({ content, cwd })
   phases.build = elapsed()
-  debug('esbuild:output', { content: result.outputFiles[0].text.length })
   content = result.outputFiles[0].text
 
   return { content, phases }

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,9 @@ const [nodeMajor] = process.version.slice(1).split('.').map(Number)
 
 const PERMISSION_FLAG = nodeMajor >= 24 ? '--permission' : '--experimental-permission'
 
+const roundMs = entries =>
+  Object.fromEntries(entries.map(([key, value]) => [key, Math.round(value)]))
+
 const flags = ({ memory, permissions }) => {
   const flags = ['--disable-warning=ExperimentalWarning', PERMISSION_FLAG]
   if (memory) flags.push(`--max-old-space-size=${memory}`)
@@ -73,7 +76,11 @@ module.exports = ({ tmpdir } = {}) => {
             total: total()
           }
         }
-        debug('node', { cpu: result.cpu, memory: result.memory, ...result.phases })
+        debug('node', {
+          cpu: Math.round(result.cpu),
+          memory: result.memory,
+          ...roundMs(Object.entries(result.phases))
+        })
 
         return isFulfilled
           ? { isFulfilled, value, profiling: result, logging }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only affect debug/profiling logging and remove `duration`-wrapped timing around install/build without altering execution flow or outputs.
> 
> **Overview**
> Removes `duration`/`debug` instrumentation from compilation (`npm install` and `esbuild` phases) so these steps run directly without extra log wrapping.
> 
> Compacts runtime debug logs by rounding `cpu` and phase timings to whole milliseconds via a new `roundMs` helper, reducing log verbosity while keeping the same profiling fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32c15f57886e0e28bf4daa09c3fdb134da10322b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->