### PR TITLE
feat: node paths

### DIFF
--- a/src/compile/build.js
+++ b/src/compile/build.js
@@ -12,7 +12,7 @@ const MINIFY = (() => {
       }
 })()
 
-module.exports = ({ content, cwd }) =>
+module.exports = ({ content, cwd, nodePaths = [] }) =>
   esbuild.build({
     stdin: {
       contents: content,
@@ -24,5 +24,6 @@ module.exports = ({ content, cwd }) =>
     platform: 'node',
     legalComments: 'eof',
     target: 'node24',
+    nodePaths,
     ...MINIFY
   })

--- a/src/compile/index.js
+++ b/src/compile/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { mkdirSync } = require('fs')
+const { mkdirSync, readFileSync } = require('fs')
 const path = require('path')
 
 const transformDependencies = require('./transform-dependencies')
@@ -24,22 +24,40 @@ const enqueueInstall = (tmpdir, dependencies, allow) => {
   return next
 }
 
-module.exports = async (snippet, { tmpdir = DEFAULT_TMPDIR, allow = {} } = {}) => {
+module.exports = async (snippet, { tmpdir = DEFAULT_TMPDIR, allow = {}, nodePaths = [] } = {}) => {
   let content = template(snippet)
   const phases = { install: 0 }
 
-  const dependencies = detectDependencies(content)
+  const allDependencies = detectDependencies(content)
+  installDependencies.validateDependencies(allDependencies, allow.dependencies)
+  const dependencies = nodePaths.length
+    ? allDependencies.filter(dep => {
+      const name = installDependencies.extractPackageName(dep)
+      const version = dep.slice(name.length + 1)
+      try {
+        const pkgPath = require.resolve(path.join(name, 'package.json'), { paths: nodePaths })
+        if (version === 'latest') return false
+        return JSON.parse(readFileSync(pkgPath, 'utf8')).version !== version
+      } catch {
+        return true
+      }
+    })
+    : allDependencies
+
   if (dependencies.length) {
     content = transformDependencies(content)
     mkdirSync(tmpdir, { recursive: true })
     const elapsed = timeSpan()
     await enqueueInstall(tmpdir, dependencies, allow)
     phases.install = elapsed()
+  } else if (allDependencies.length) {
+    content = transformDependencies(content)
+    mkdirSync(tmpdir, { recursive: true })
   }
 
-  const cwd = dependencies.length ? tmpdir : process.cwd()
+  const cwd = allDependencies.length ? tmpdir : process.cwd()
   const elapsed = timeSpan()
-  const result = await build({ content, cwd })
+  const result = await build({ content, cwd, nodePaths })
   phases.build = elapsed()
   content = result.outputFiles[0].text
 

--- a/src/compile/install-dependencies.js
+++ b/src/compile/install-dependencies.js
@@ -56,3 +56,6 @@ module.exports = async ({ dependencies, cwd, allow = {} }) => {
   validateDependencies(dependencies, allow.dependencies)
   return $(`${install} ${dependencies.join(' ')}`, { cwd, env: { ...process.env, CI: true } })
 }
+
+module.exports.validateDependencies = validateDependencies
+module.exports.extractPackageName = extractPackageName

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -73,6 +73,8 @@ export interface AllowOptions {
 export interface CreateOptions {
   /** Directory for installing code dependencies. Reused across invocations. */
   tmpdir?: string
+  /** Additional directories for resolving dependencies. Dependencies found here with a matching version skip npm install. */
+  nodePaths?: string[]
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -40,11 +40,11 @@ const spawn = ({ args, env, timeout }) => {
   return $('node', ['-', args], spawnOpts)
 }
 
-module.exports = ({ tmpdir } = {}) => {
+module.exports = ({ tmpdir, nodePaths } = {}) => {
   const isolatedFunction = (snippet, { timeout, memory, throwError = true, allow = {} } = {}) => {
     if (!['function', 'string'].includes(typeof snippet)) throw new TypeError('Expected a function')
     const { permissions = [] } = allow
-    const compilePromise = compile(snippet, { tmpdir, allow })
+    const compilePromise = compile(snippet, { tmpdir, allow, nodePaths })
 
     return async (...args) => {
       let total


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes dependency detection/installation flow and module resolution (via `nodePaths`), which can alter what gets bundled or when installs occur; risk is moderate due to potential resolution/version edge cases.
> 
> **Overview**
> Adds a new `nodePaths` option to the public API and TypeScript types, threading it through compilation and bundling.
> 
> During compilation, dependencies are now validated up-front and, when `nodePaths` is provided, `npm/pnpm install` is skipped for packages already resolvable from those paths with a matching version; esbuild is also configured with `nodePaths` for resolution. `install-dependencies` now exports `validateDependencies` and `extractPackageName` for reuse in this filtering logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b047c42963a911c010d3863dc2f5c52f04efb654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->